### PR TITLE
Set tailscale env var so that nftables works

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -44,6 +44,7 @@
     content: |
       [Service]
       LogLevelMax=notice
+      Environment=TS_DEBUG_FIREWALL_MODE=auto
     owner: root
     group: root
     mode: '0644'


### PR DESCRIPTION
This commit adds the env `TS_DEBUG_FIREWALL_MODE=auto` without it
tailscale uses legacy iptables which does not work on Ubuntu 22.04+

I tested this env flag on multiple Ubuntu 22.04 servers, and Ubuntu
20.04 servers.  Not sure about Ubuntu 24.04 or Rocky Linux based
systems.
