### PR TITLE
fix: update status to not get status for peers

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Fetch Tailscale status
   listen: Confirm Tailscale is Connected
-  ansible.builtin.command: tailscale status --json
+  ansible.builtin.command: tailscale status --peers=false --json
   changed_when: false
   register: tailscale_status
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -95,7 +95,7 @@
     enabled: true
 
 - name: Install | Fetch Tailscale status
-  ansible.builtin.command: tailscale status --json
+  ansible.builtin.command: tailscale status --peers=false --json
   changed_when: false
   register: tailscale_status
 

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -43,7 +43,7 @@
 - name: Uninstall | De-register Tailscale Node
   become: true
   # Hack to get correct changed/ok status
-  ansible.builtin.command: tailscale status --peers=false --json; tailscale logout ; tailscale bugreport
+  ansible.builtin.shell: tailscale status --peers=false --json; tailscale logout ; tailscale bugreport
   register: tailscale_logout
   changed_when: "'Logged out.' not in tailscale_status.stdout and 'not logged in' not in tailscale_status.stdout"
   when:

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -1,6 +1,6 @@
 ---
 - name: Uninstall | Check If Tailscale Is Connected
-  ansible.builtin.command: tailscale status
+  ansible.builtin.command: tailscale status --peers=false --json
   changed_when: false
   failed_when: false
   register: tailscale_status
@@ -43,7 +43,7 @@
 - name: Uninstall | De-register Tailscale Node
   become: true
   # Hack to get correct changed/ok status
-  ansible.builtin.shell: tailscale status; tailscale logout ; tailscale bugreport
+  ansible.builtin.command: tailscale status --peers=false --json; tailscale logout ; tailscale bugreport
   register: tailscale_logout
   changed_when: "'Logged out.' not in tailscale_status.stdout and 'not logged in' not in tailscale_status.stdout"
   when:


### PR DESCRIPTION
Im creating this PR because `tailscale status` has thousands of lines of output. We don't need to see status of every server during this role run. Settting these flags will disable peer output. 